### PR TITLE
NXP-12608 Fix for import crash when arbitrary queue length of GenericMultiThreadedImporter.importTP exceeded

### DIFF
--- a/nuxeo-importer-core/src/main/java/org/nuxeo/ecm/platform/importer/base/GenericMultiThreadedImporter.java
+++ b/nuxeo-importer-core/src/main/java/org/nuxeo/ecm/platform/importer/base/GenericMultiThreadedImporter.java
@@ -307,7 +307,7 @@ public class GenericMultiThreadedImporter implements ImporterRunner {
         nbCreatedDocsByThreads = new ConcurrentHashMap<String, Long>();
 
         importTP = new ThreadPoolExecutor(nbThreads, nbThreads, 500L,
-                TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>(100),
+                TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>(),
                 new NamedThreadFactory("Nuxeo-Importer-"));
 
         initRootTask(importSource, targetContainer, skipRootContainerCreation,


### PR DESCRIPTION
[https://jira.nuxeo.com/browse/NXP-12608]
NXP-12608 Fix for import crash when arbitrary queue length of GenericMultiThreadedImporter.importTP exceeded
