### PR TITLE
NXP-25288: Fix fourStepsImportFileBlob random on mysql/mariadb

### DIFF
--- a/nuxeo-importer-stream/src/test/java/org/nuxeo/importer/stream/tests/importer/TestDocumentImport.java
+++ b/nuxeo-importer-stream/src/test/java/org/nuxeo/importer/stream/tests/importer/TestDocumentImport.java
@@ -64,6 +64,7 @@ import org.nuxeo.runtime.api.Framework;
 import org.nuxeo.runtime.test.runner.Deploy;
 import org.nuxeo.runtime.test.runner.Features;
 import org.nuxeo.runtime.test.runner.FeaturesRunner;
+import org.nuxeo.runtime.transaction.TransactionHelper;
 
 @RunWith(FeaturesRunner.class)
 @Features({ CoreFeature.class, RedisFeature.class })
@@ -214,6 +215,11 @@ public abstract class TestDocumentImport {
         }
         WorkManager service = Framework.getService(WorkManager.class);
         assertTrue(service.awaitCompletion(10, TimeUnit.SECONDS));
+
+        // make sure there is no visibility pb with mysql
+        TransactionHelper.commitOrRollbackTransaction();
+        TransactionHelper.startTransaction();
+
         DocumentModelList docs = session.query("SELECT * FROM Document");
         assertEquals(NB_DOCUMENTS * NB_PRODUCERS, docs.totalSize());
 


### PR DESCRIPTION
T&P was in failure due to another reason and now CI is not available until 10.2 branch is created, could be reviewed in the mean time.